### PR TITLE
GPO Security Settings resource [3/13]: event audit section

### DIFF
--- a/ad/internal/gposec/event_audit.go
+++ b/ad/internal/gposec/event_audit.go
@@ -1,0 +1,35 @@
+package gposec
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/mitchellh/mapstructure"
+)
+
+// EventAudit represents the event audit policies section of the Security Settings GPO extension
+type EventAudit struct {
+	AuditAccountManage   string `ini:",omitempty" mapstructure:"audit_account_manage"`
+	AuditDSAccess        string `ini:",omitempty" mapstructure:"audit_ds_access"`
+	AuditAccountLogon    string `ini:",omitempty" mapstructure:"audit_account_logon"`
+	AuditLogonEvents     string `ini:",omitempty" mapstructure:"audit_logon_events"`
+	AuditObjectAccess    string `ini:",omitempty" mapstructure:"audit_object_access"`
+	AuditPolicyChange    string `ini:",omitempty" mapstructure:"audit_policy_change"`
+	AuditPrivilegeUse    string `ini:",omitempty" mapstructure:"audit_privilege_use"`
+	AuditProcessTracking string `ini:",omitempty" mapstructure:"audit_process_tracking"`
+	AuditSystemEvents    string `ini:",omitempty" mapstructure:"audit_system_events"`
+}
+
+// SetResourceData populates resource data based on the EventAudit field values
+func (p *EventAudit) SetResourceData(section string, d *schema.ResourceData) error {
+	return genericSetResourceData(section, p, d)
+}
+
+// WriteEventAudit populates an EventAudit struct from resource data
+func WriteEventAudit(data interface{}, cfg *SecuritySettings) error {
+	eap := &EventAudit{}
+	err := mapstructure.Decode(data.(map[string]interface{}), eap)
+	if err != nil {
+		return err
+	}
+	cfg.EventAudit = eap
+	return nil
+}

--- a/ad/internal/gposec/event_audit_test.go
+++ b/ad/internal/gposec/event_audit_test.go
@@ -1,0 +1,46 @@
+package gposec
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-ad/ad/internal/adschema"
+)
+
+func TestWriteEventAudit(t *testing.T) {
+	data := map[string]interface{}{
+		"audit_logon_events": "1",
+	}
+
+	out := NewSecuritySettings()
+	err := WriteEventAudit(data, out)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if out.EventAudit == nil {
+		t.Errorf("EventAudit struct is nil.")
+		t.FailNow()
+	}
+
+	if out.EventAudit.AuditLogonEvents != "1" {
+		t.Errorf("mismatch: MaximumLogSize. Expected 10 found %q", out.AuditLog.MaximumLogSize)
+	}
+}
+
+func TestEventAuditSetResourceData(t *testing.T) {
+	r := schema.Resource{}
+	r.Schema = adschema.GpoSecuritySchema()
+	d := r.TestResourceData()
+
+	al := EventAudit{
+		AuditAccountLogon: "10",
+	}
+	al.SetResourceData("event_audit", d)
+
+	mls := d.Get("event_audit.0.audit_account_logon").(string)
+
+	if mls != "10" {
+		t.Errorf("unexpected value of event_audit.0.audit_account_logon. Expected 10 got %q", mls)
+	}
+}


### PR DESCRIPTION
The security settings resource is too large to push into a single PR so I am breaking this into pieces, just to make reviews easier. This will not be functional until all PRs are merged.