### PR TITLE
Fix small typo on ad/provider.go and docs/index.md

### DIFF
--- a/ad/provider.go
+++ b/ad/provider.go
@@ -16,13 +16,13 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("AD_USER", nil),
-				Description: "The username used to authenticate to the the server's WinRM service. (Environment variable: AD_USER)",
+				Description: "The username used to authenticate to the server's WinRM service. (Environment variable: AD_USER)",
 			},
 			"winrm_password": {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("AD_PASSWORD", nil),
-				Description: "The password used to authenticate to the the server's WinRM service. (Environment variable: AD_PASSWORD)",
+				Description: "The password used to authenticate to the server's WinRM service. (Environment variable: AD_PASSWORD)",
 			},
 			"winrm_hostname": {
 				Type:        schema.TypeString,

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,8 +45,8 @@ resource "ad_gplink" "og" {
 ### Required
 
 - **winrm_hostname** (String, Required) The hostname of the server we will use to run powershell scripts over WinRM. (Environment variable: AD_HOSTNAME)
-- **winrm_password** (String, Required) The password used to authenticate to the the server's WinRM service. (Environment variable: AD_PASSWORD)
-- **winrm_username** (String, Required) The username used to authenticate to the the server's WinRM service. (Environment variable: AD_USER)
+- **winrm_password** (String, Required) The password used to authenticate to the server's WinRM service. (Environment variable: AD_PASSWORD)
+- **winrm_username** (String, Required) The username used to authenticate to the server's WinRM service. (Environment variable: AD_USER)
 
 ### Optional
 


### PR DESCRIPTION
### Description

Minor fix on typo that involved consecutive "the" ocurrences.
`s/the /the the /g`

### References
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
