### PR TITLE
Allow dependabot to check go dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
+    vendor: "true"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
### Description

This change allows dependabot to check go dependencies which this project uses and submit PRs automatically with version bumps in order to keep dependencies up-to-date. Below is the link to some dependabot documentation.

https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#vendor

### References

I don't believe there are any tickets in for this related change.

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
