### PR TITLE
Export SID for security principals

### DIFF
--- a/ad/data_source_ad_computer.go
+++ b/ad/data_source_ad_computer.go
@@ -27,6 +27,11 @@ func dataSourceADComputer() *schema.Resource {
 				Optional:    true,
 				Description: "The Distinguished Name of the computer object.",
 			},
+			"sid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The SID of the computer object.",
+			},
 		},
 	}
 }
@@ -59,6 +64,7 @@ func dataSourceADComputerRead(d *schema.ResourceData, meta interface{}) error {
 	_ = d.Set("name", computer.Name)
 	_ = d.Set("dn", computer.DN)
 	_ = d.Set("guid", computer.GUID)
+	_ = d.Set("sid", computer.SID.Value)
 
 	return nil
 }

--- a/ad/data_source_ad_group.go
+++ b/ad/data_source_ad_group.go
@@ -51,7 +51,7 @@ func dataSourceADGroup() *schema.Resource {
 			"sid": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The SID of the computer object.",
+				Description: "The SID of the group object.",
 			},
 		},
 	}

--- a/ad/data_source_ad_group.go
+++ b/ad/data_source_ad_group.go
@@ -48,6 +48,11 @@ func dataSourceADGroup() *schema.Resource {
 				Computed:    true,
 				Description: "The Group's container object.",
 			},
+			"sid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The SID of the computer object.",
+			},
 		},
 	}
 }
@@ -75,6 +80,7 @@ func dataSourceADGroupRead(d *schema.ResourceData, meta interface{}) error {
 	_ = d.Set("container", g.Container)
 	_ = d.Set("name", g.Name)
 	_ = d.Set("group_id", groupID)
+	_ = d.Set("sid", g.SID.Value)
 
 	d.SetId(g.GUID)
 	return nil

--- a/ad/data_source_ad_user.go
+++ b/ad/data_source_ad_user.go
@@ -151,7 +151,7 @@ func dataSourceADUser() *schema.Resource {
 			"sid": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The SID of the computer object.",
+				Description: "The SID of the user object.",
 			},
 			"smart_card_logon_required": {
 				Type:        schema.TypeBool,

--- a/ad/data_source_ad_user.go
+++ b/ad/data_source_ad_user.go
@@ -206,7 +206,7 @@ func dataSourceADUserRead(d *schema.ResourceData, meta interface{}) error {
 	_ = d.Set("sam_account_name", u.SAMAccountName)
 	_ = d.Set("display_name", u.DisplayName)
 	_ = d.Set("principal_name", u.PrincipalName)
-	_ = d.Set("guid", u.GUID)
+	_ = d.Set("user_id", u.GUID)
 	_ = d.Set("city", u.City)
 	_ = d.Set("company", u.Company)
 	_ = d.Set("country", u.Country)

--- a/ad/data_source_ad_user.go
+++ b/ad/data_source_ad_user.go
@@ -148,6 +148,11 @@ func dataSourceADUser() *schema.Resource {
 				Computed:    true,
 				Description: "Postal code of the user object.",
 			},
+			"sid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The SID of the computer object.",
+			},
 			"smart_card_logon_required": {
 				Type:        schema.TypeBool,
 				Computed:    true,
@@ -225,6 +230,7 @@ func dataSourceADUserRead(d *schema.ResourceData, meta interface{}) error {
 	_ = d.Set("other_name", u.OtherName)
 	_ = d.Set("po_box", u.POBox)
 	_ = d.Set("postal_code", u.PostalCode)
+	_ = d.Set("sid", u.SID.Value)
 	_ = d.Set("state", u.State)
 	_ = d.Set("street_address", u.StreetAddress)
 	_ = d.Set("surname", u.Surname)

--- a/ad/internal/winrmhelper/winrm_computer.go
+++ b/ad/internal/winrmhelper/winrm_computer.go
@@ -17,6 +17,7 @@ type Computer struct {
 	DN             string `json:"DistinguishedName"`
 	SAMAccountName string `json:"SamAccountName"`
 	Path           string
+	SID            SID `json:"SID"`
 }
 
 // NewComputerFromResource returns a new Machine struct populated from resource data

--- a/ad/internal/winrmhelper/winrm_group.go
+++ b/ad/internal/winrmhelper/winrm_group.go
@@ -21,6 +21,7 @@ type Group struct {
 	Scope             string
 	Category          string
 	Container         string
+	SID               SID `json:"SID"`
 }
 
 // AddGroup creates a new group

--- a/ad/internal/winrmhelper/winrm_helper.go
+++ b/ad/internal/winrmhelper/winrm_helper.go
@@ -13,6 +13,12 @@ import (
 	"github.com/masterzen/winrm"
 )
 
+// SID is a common structure by all "security principals". This means domains, users, computers, and groups.
+// The structure we get from powershell contains more fields, but we're only interested in the Value.
+type SID struct {
+	Value string `json:"Value"`
+}
+
 //WinRMResult holds the stdout, stderr and exit code of a powershell command
 type WinRMResult struct {
 	Stdout   string

--- a/ad/internal/winrmhelper/winrm_user.go
+++ b/ad/internal/winrmhelper/winrm_user.go
@@ -44,6 +44,7 @@ type User struct {
 	OtherName              string
 	POBox                  string
 	PostalCode             string
+	SID                    SID `json:"SID"`
 	SmartcardLogonRequired bool
 	State                  string
 	StreetAddress          string

--- a/ad/resource_ad_computer.go
+++ b/ad/resource_ad_computer.go
@@ -47,6 +47,11 @@ func resourceADComputer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"sid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The SID of the computer object.",
+			},
 		},
 	}
 }
@@ -76,6 +81,7 @@ func resourceADComputerRead(d *schema.ResourceData, meta interface{}) error {
 	_ = d.Set("guid", computer.GUID)
 	_ = d.Set("pre2kname", computer.SAMAccountName)
 	_ = d.Set("container", computer.Path)
+	_ = d.Set("sid", computer.SID.Value)
 
 	return nil
 }

--- a/ad/resource_ad_group.go
+++ b/ad/resource_ad_group.go
@@ -54,7 +54,7 @@ func resourceADGroup() *schema.Resource {
 			"sid": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The SID of the computer object.",
+				Description: "The SID of the group object.",
 			},
 		},
 	}

--- a/ad/resource_ad_group.go
+++ b/ad/resource_ad_group.go
@@ -51,6 +51,11 @@ func resourceADGroup() *schema.Resource {
 				Description:      "A DN of a container object holding the group.",
 				DiffSuppressFunc: suppressCaseDiff,
 			},
+			"sid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The SID of the computer object.",
+			},
 		},
 	}
 }
@@ -96,6 +101,7 @@ func resourceADGroupRead(d *schema.ResourceData, meta interface{}) error {
 	_ = d.Set("scope", g.Scope)
 	_ = d.Set("category", g.Category)
 	_ = d.Set("container", g.Container)
+	_ = d.Set("sid", g.SID.Value)
 
 	return nil
 }

--- a/ad/resource_ad_user.go
+++ b/ad/resource_ad_user.go
@@ -227,7 +227,7 @@ func resourceADUser() *schema.Resource {
 			"sid": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The SID of the computer object.",
+				Description: "The SID of the user object.",
 			},
 		},
 	}

--- a/ad/resource_ad_user.go
+++ b/ad/resource_ad_user.go
@@ -224,6 +224,11 @@ func resourceADUser() *schema.Resource {
 				ValidateFunc:     validation.StringIsJSON,
 				DiffSuppressFunc: suppressJsonDiff,
 			},
+			"sid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The SID of the computer object.",
+			},
 		},
 	}
 }
@@ -333,6 +338,7 @@ func resourceADUserRead(d *schema.ResourceData, meta interface{}) error {
 	_ = d.Set("other_name", u.OtherName)
 	_ = d.Set("po_box", u.POBox)
 	_ = d.Set("postal_code", u.PostalCode)
+	_ = d.Set("sid", u.SID.Value)
 	_ = d.Set("state", u.State)
 	_ = d.Set("street_address", u.StreetAddress)
 	_ = d.Set("surname", u.Surname)

--- a/docs/data-sources/computer.md
+++ b/docs/data-sources/computer.md
@@ -32,5 +32,6 @@ output "computer_guid" {
 ### Read-only
 
 - **name** (String, Read-only) The name of the computer object.
+- **sid** (String, Read-only) The SID of the computer object.
 
 

--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -47,5 +47,6 @@ output "g2_guid" {
 - **name** (String, Read-only) The name of the Group object.
 - **sam_account_name** (String, Read-only) The SAM account name of the Group object.
 - **scope** (String, Read-only) The Group's scope.
+- **sid** (String, Read-only) The SID of the group object.
 
 

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -75,6 +75,7 @@ output "testuser_guid" {
 - **postal_code** (String, Read-only) Postal code of the user object.
 - **principal_name** (String, Read-only) The principal name of the user object.
 - **sam_account_name** (String, Read-only) The SAM account name of the user object.
+- **sid** (String, Read-only) The SID of the user object.
 - **smart_card_logon_required** (Boolean, Read-only) Smart card required to logon or not
 - **state** (String, Read-only) State of the user object.
 - **street_address** (String, Read-only) Address of the user object.

--- a/docs/resources/computer.md
+++ b/docs/resources/computer.md
@@ -37,6 +37,7 @@ resource "ad_computer" "c" {
 
 - **dn** (String, Read-only)
 - **guid** (String, Read-only)
+- **sid** (String, Read-only) The SID of the computer object.
 
 ## Import
 

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -53,6 +53,10 @@ resource "ad_group" "g" {
 - **id** (String, Optional) The ID of this resource.
 - **scope** (String, Optional) The group's scope. Can be one of `global`, `local`, or `universal` (case sensitive).
 
+### Read-only
+
+- **sid** (String, Read-only) The SID of the group object.
+
 ## Import
 
 Import is supported using the following syntax:

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -117,6 +117,10 @@ resource "ad_user" "u2" {
 - **title** (String, Optional) Specifies the user's title. This parameter sets the Title property of a user object
 - **trusted_for_delegation** (Boolean, Optional) If set to true, the user account is trusted for Kerberos delegation. A service that runs under an account that is trusted for Kerberos delegation can assume the identity of a client requesting the service. This parameter sets the TrustedForDelegation property of an account object.
 
+### Read-only
+
+- **sid** (String, Read-only) The SID of the user object.
+
 ## Import
 
 Import is supported using the following syntax:


### PR DESCRIPTION
    Export SID for Security Principals objects

    Add a computed field that holds an object's SID.
    This applies to user, group, and computer resources and datasources.

    Closes #60.
