### PR TITLE
Issue 70 local + add provider examples in documentation

### DIFF
--- a/ad/data_source_ad_computer.go
+++ b/ad/data_source_ad_computer.go
@@ -37,6 +37,7 @@ func dataSourceADComputer() *schema.Resource {
 }
 
 func dataSourceADComputerRead(d *schema.ResourceData, meta interface{}) error {
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
 		return err
@@ -55,7 +56,7 @@ func dataSourceADComputerRead(d *schema.ResourceData, meta interface{}) error {
 		identity = dn
 	}
 
-	computer, err := winrmhelper.NewComputerFromHost(client, identity)
+	computer, err := winrmhelper.NewComputerFromHost(client, identity, isLocal)
 	if err != nil {
 		return err
 	}

--- a/ad/data_source_ad_gpo.go
+++ b/ad/data_source_ad_gpo.go
@@ -32,6 +32,7 @@ func dataSourceADGPO() *schema.Resource {
 }
 
 func dataSourceADGPORead(d *schema.ResourceData, meta interface{}) error {
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 	name := winrmhelper.SanitiseTFInput(d, "name")
 	guid := winrmhelper.SanitiseTFInput(d, "guid")
 
@@ -41,7 +42,7 @@ func dataSourceADGPORead(d *schema.ResourceData, meta interface{}) error {
 	}
 	defer meta.(ProviderConf).ReleaseWinRMClient(client)
 
-	gpo, err := winrmhelper.GetGPOFromHost(client, name, guid)
+	gpo, err := winrmhelper.GetGPOFromHost(client, name, guid, isLocal)
 	if err != nil {
 		if strings.Contains(err.Error(), "GpoWithNameNotFound") || strings.Contains(err.Error(), "GpoWithIdNotFound") {
 			d.SetId("")

--- a/ad/data_source_ad_group.go
+++ b/ad/data_source_ad_group.go
@@ -58,6 +58,7 @@ func dataSourceADGroup() *schema.Resource {
 }
 
 func dataSourceADGroupRead(d *schema.ResourceData, meta interface{}) error {
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
 		return err
@@ -66,7 +67,7 @@ func dataSourceADGroupRead(d *schema.ResourceData, meta interface{}) error {
 
 	groupID := d.Get("group_id").(string)
 
-	g, err := winrmhelper.GetGroupFromHost(client, groupID)
+	g, err := winrmhelper.GetGroupFromHost(client, groupID, isLocal)
 	if err != nil {
 		return err
 	}

--- a/ad/data_source_ad_ou.go
+++ b/ad/data_source_ad_ou.go
@@ -43,6 +43,7 @@ func dataSourceADOU() *schema.Resource {
 }
 
 func dataSourceADOURead(d *schema.ResourceData, meta interface{}) error {
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
 		return err
@@ -57,7 +58,7 @@ func dataSourceADOURead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("invalid inputs, dn or a combination of path and name are required")
 	}
 
-	ou, err := winrmhelper.NewOrgUnitFromHost(client, dn, name, path)
+	ou, err := winrmhelper.NewOrgUnitFromHost(client, dn, name, path, isLocal)
 	if err != nil {
 		return err
 	}

--- a/ad/data_source_ad_user.go
+++ b/ad/data_source_ad_user.go
@@ -188,6 +188,7 @@ func dataSourceADUser() *schema.Resource {
 }
 
 func dataSourceADUserRead(d *schema.ResourceData, meta interface{}) error {
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 	userID := d.Get("user_id").(string)
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
@@ -195,7 +196,7 @@ func dataSourceADUserRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	defer meta.(ProviderConf).ReleaseWinRMClient(client)
 
-	u, err := winrmhelper.GetUserFromHost(client, userID, nil)
+	u, err := winrmhelper.GetUserFromHost(client, userID, nil, isLocal)
 	if err != nil {
 		return err
 	}

--- a/ad/internal/winrmhelper/winrm_group.go
+++ b/ad/internal/winrmhelper/winrm_group.go
@@ -25,7 +25,7 @@ type Group struct {
 }
 
 // AddGroup creates a new group
-func (g *Group) AddGroup(client *winrm.Client) (string, error) {
+func (g *Group) AddGroup(client *winrm.Client, execLocally bool) (string, error) {
 	log.Printf("[DEBUG] Adding group with name %q", g.Name)
 	cmds := []string{fmt.Sprintf("New-ADGroup -Passthru -Name %q -GroupScope %q -GroupCategory %q -Path %q", g.Name, g.Scope, g.Category, g.Container)}
 
@@ -33,7 +33,7 @@ func (g *Group) AddGroup(client *winrm.Client) (string, error) {
 		cmds = append(cmds, fmt.Sprintf("-SamAccountName %q", g.SAMAccountName))
 	}
 
-	result, err := RunWinRMCommand(client, cmds, true, false)
+	result, err := RunWinRMCommand(client, cmds, true, false, execLocally)
 	if err != nil {
 		return "", err
 	}
@@ -55,7 +55,7 @@ func (g *Group) AddGroup(client *winrm.Client) (string, error) {
 }
 
 // ModifyGroup updates an existing group
-func (g *Group) ModifyGroup(d *schema.ResourceData, client *winrm.Client) error {
+func (g *Group) ModifyGroup(d *schema.ResourceData, client *winrm.Client, execLocally bool) error {
 	keyMap := map[string]string{
 		"sam_account_name": "SamAccountName",
 		"scope":            "GroupScope",
@@ -71,7 +71,7 @@ func (g *Group) ModifyGroup(d *schema.ResourceData, client *winrm.Client) error 
 	}
 
 	if len(cmds) > 1 {
-		result, err := RunWinRMCommand(client, cmds, false, false)
+		result, err := RunWinRMCommand(client, cmds, false, false, execLocally)
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ func (g *Group) ModifyGroup(d *schema.ResourceData, client *winrm.Client) error 
 
 	if d.HasChange("name") {
 		cmds := []string{"Rename-ADObject -Identity %q -NewName %q", g.GUID, d.Get("name").(string)}
-		result, err := RunWinRMCommand(client, cmds, false, false)
+		result, err := RunWinRMCommand(client, cmds, false, false, execLocally)
 		if err != nil {
 			return err
 		}
@@ -95,7 +95,7 @@ func (g *Group) ModifyGroup(d *schema.ResourceData, client *winrm.Client) error 
 
 	if d.HasChange("container") {
 		cmds := []string{"Rename-ADObject -Identity %q -NewName %q", g.GUID, d.Get("name").(string)}
-		result, err := RunWinRMCommand(client, cmds, false, false)
+		result, err := RunWinRMCommand(client, cmds, false, false, execLocally)
 		if err != nil {
 			return err
 		}
@@ -110,9 +110,9 @@ func (g *Group) ModifyGroup(d *schema.ResourceData, client *winrm.Client) error 
 }
 
 // DeleteGroup removes a group
-func (g *Group) DeleteGroup(client *winrm.Client) error {
+func (g *Group) DeleteGroup(client *winrm.Client, execLocally bool) error {
 	cmd := fmt.Sprintf("Remove-ADGroup -Identity %s -Confirm:$false", g.GUID)
-	_, err := RunWinRMCommand(client, []string{cmd}, false, false)
+	_, err := RunWinRMCommand(client, []string{cmd}, false, false, execLocally)
 	if err != nil {
 		// Check if the resource is already deleted
 		if strings.Contains(err.Error(), "ADIdentityNotFoundException") {
@@ -138,9 +138,9 @@ func GetGroupFromResource(d *schema.ResourceData) *Group {
 
 // GetGroupFromHost returns a Group struct based on data
 // retrieved from the AD Controller.
-func GetGroupFromHost(client *winrm.Client, guid string) (*Group, error) {
+func GetGroupFromHost(client *winrm.Client, guid string, execLocally bool) (*Group, error) {
 	cmd := fmt.Sprintf("Get-ADGroup -identity %q -properties *", guid)
-	result, err := RunWinRMCommand(client, []string{cmd}, true, false)
+	result, err := RunWinRMCommand(client, []string{cmd}, true, false, execLocally)
 	if err != nil {
 		return nil, err
 	}

--- a/ad/internal/winrmhelper/winrm_helper.go
+++ b/ad/internal/winrmhelper/winrm_helper.go
@@ -164,6 +164,7 @@ func RunWinRMCommand(conn *winrm.Client, cmds []string, json bool, forceArray bo
 	)
 
 	if execLocally == false && conn != nil {
+		log.Printf("[DEBUG] Running command remotely")
 		stdout, stderr, res, err = conn.RunWithString(encodedCmd, "")
 		log.Printf("[DEBUG] Powershell command exited with code %d", res)
 
@@ -173,6 +174,7 @@ func RunWinRMCommand(conn *winrm.Client, cmds []string, json bool, forceArray bo
 		}
 
 	} else {
+		log.Printf("[DEBUG] Running command locally")
 		shell := NewPS()
 		stdout, stderr, res = shell.execute(encodedCmd)
 	}
@@ -231,9 +233,9 @@ func SanitiseString(key string) string {
 
 // SetMachineExtensionName will add the necessary GUIDs to the GPO's gPCMachineExtensionNames attribute.
 // These are required for the security settings part of a GPO to work.
-func SetMachineExtensionNames(client *winrm.Client, gpoDN, value string) error {
+func SetMachineExtensionNames(client *winrm.Client, gpoDN, value string, execLocally bool) error {
 	cmd := fmt.Sprintf(`Set-ADObject -Identity "%s" -Replace @{gPCMachineExtensionNames="%s"}`, gpoDN, value)
-	result, err := RunWinRMCommand(client, []string{cmd}, false, false)
+	result, err := RunWinRMCommand(client, []string{cmd}, false, false, execLocally)
 	if err != nil {
 		return fmt.Errorf("error while setting machine extension names for GPO %q: %s", gpoDN, err)
 	}

--- a/ad/internal/winrmhelper/winrm_ou.go
+++ b/ad/internal/winrmhelper/winrm_ou.go
@@ -36,7 +36,7 @@ func NewOrgUnitFromResource(d *schema.ResourceData) *OrgUnit {
 
 // NewOrgUnitFromHost returns a new OrgUnit struct populated from data we get from
 // the domain controller
-func NewOrgUnitFromHost(conn *winrm.Client, guid, name, path string) (*OrgUnit, error) {
+func NewOrgUnitFromHost(conn *winrm.Client, guid, name, path string, execLocally bool) (*OrgUnit, error) {
 	var cmd string
 	if guid != "" {
 		cmd = fmt.Sprintf("Get-ADObject -Properties * -Identity %q", guid)
@@ -46,7 +46,7 @@ func NewOrgUnitFromHost(conn *winrm.Client, guid, name, path string) (*OrgUnit, 
 		return nil, fmt.Errorf("invalid inputs, dn or a combination of path and name are required")
 	}
 
-	result, err := RunWinRMCommand(conn, []string{cmd}, true, false)
+	result, err := RunWinRMCommand(conn, []string{cmd}, true, false, execLocally)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func NewOrgUnitFromHost(conn *winrm.Client, guid, name, path string) (*OrgUnit, 
 }
 
 // Create creates a new OU in the AD tree
-func (o *OrgUnit) Create(conn *winrm.Client) (string, error) {
+func (o *OrgUnit) Create(conn *winrm.Client, execLocally bool) (string, error) {
 
 	cmd := "New-ADOrganizationalUnit -Passthru"
 	if o.Name == "" {
@@ -81,7 +81,7 @@ func (o *OrgUnit) Create(conn *winrm.Client) (string, error) {
 
 	cmd = fmt.Sprintf("%s -ProtectedFromAccidentalDeletion:$%t", cmd, o.Protected)
 
-	result, err := RunWinRMCommand(conn, []string{cmd}, true, false)
+	result, err := RunWinRMCommand(conn, []string{cmd}, true, false, execLocally)
 	if err != nil {
 		return "", err
 	}
@@ -97,7 +97,7 @@ func (o *OrgUnit) Create(conn *winrm.Client) (string, error) {
 }
 
 // Update updates an existing OU in the AD tree
-func (o *OrgUnit) Update(conn *winrm.Client, changes map[string]interface{}) error {
+func (o *OrgUnit) Update(conn *winrm.Client, changes map[string]interface{}, execLocally bool) error {
 	if o.DistinguishedName == "" {
 		return fmt.Errorf("Cannot update OU with name %q, distiguished name is empty", o.Name)
 	}
@@ -116,7 +116,7 @@ func (o *OrgUnit) Update(conn *winrm.Client, changes map[string]interface{}) err
 	}
 
 	if cmd != "Set-ADOrganizationalUnit -Identity" {
-		result, err := RunWinRMCommand(conn, []string{cmd}, true, false)
+		result, err := RunWinRMCommand(conn, []string{cmd}, true, false, execLocally)
 		if err != nil {
 			return err
 		}
@@ -127,7 +127,7 @@ func (o *OrgUnit) Update(conn *winrm.Client, changes map[string]interface{}) err
 
 	if protected, ok := changes["protected"]; ok {
 		cmd = fmt.Sprintf("Set-ADObject -Identity %s -ProtectedFromAccidentalDeletion:$%t", o.GUID, protected.(bool))
-		result, err := RunWinRMCommand(conn, []string{cmd}, true, false)
+		result, err := RunWinRMCommand(conn, []string{cmd}, true, false, execLocally)
 		if err != nil {
 			return err
 		}
@@ -138,7 +138,7 @@ func (o *OrgUnit) Update(conn *winrm.Client, changes map[string]interface{}) err
 
 	if name, ok := changes["name"]; ok {
 		cmd = fmt.Sprintf("Rename-ADObject -Identity %q %q ", o.GUID, name.(string))
-		result, err := RunWinRMCommand(conn, []string{cmd}, true, false)
+		result, err := RunWinRMCommand(conn, []string{cmd}, true, false, execLocally)
 		if err != nil {
 			return err
 		}
@@ -151,12 +151,12 @@ func (o *OrgUnit) Update(conn *winrm.Client, changes map[string]interface{}) err
 }
 
 // Delete deletes an existing OU from an AD tree
-func (o *OrgUnit) Delete(conn *winrm.Client) error {
+func (o *OrgUnit) Delete(conn *winrm.Client, execLocally bool) error {
 	if o.DistinguishedName == "" {
 		return fmt.Errorf("Cannot remove OU with name %q, distiguished name is empty", o.Name)
 	}
 	cmd := fmt.Sprintf("Get-ADObject -Properties * -Identity %q | Set-ADObject -ProtectedFromAccidentalDeletion:$false -Passthru | Remove-ADOrganizationalUnit -confirm:$false", o.DistinguishedName)
-	result, err := RunWinRMCommand(conn, []string{cmd}, true, false)
+	result, err := RunWinRMCommand(conn, []string{cmd}, true, false, execLocally)
 	if err != nil {
 		return err
 	}

--- a/ad/provider.go
+++ b/ad/provider.go
@@ -17,19 +17,19 @@ func Provider() *schema.Provider {
 		Schema: map[string]*schema.Schema{
 			"winrm_username": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("AD_USER", nil),
 				Description: "The username used to authenticate to the server's WinRM service. (Environment variable: AD_USER)",
 			},
 			"winrm_password": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("AD_PASSWORD", nil),
 				Description: "The password used to authenticate to the server's WinRM service. (Environment variable: AD_PASSWORD)",
 			},
 			"winrm_hostname": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("AD_HOSTNAME", nil),
 				Description: "The hostname of the server we will use to run powershell scripts over WinRM. (Environment variable: AD_HOSTNAME)",
 			},

--- a/ad/provider.go
+++ b/ad/provider.go
@@ -1,6 +1,8 @@
 package ad
 
 import (
+	"log"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -147,6 +149,23 @@ func (pcfg ProviderConf) ReleaseWinRMCPClient(winRMCPClient *winrmcp.Winrmcp) {
 	pcfg.mx.Lock()
 	defer pcfg.mx.Unlock()
 	pcfg.winRMCPClients = append(pcfg.winRMCPClients, winRMCPClient)
+}
+
+// isConnectionTypeLocal check if connection is local
+func (pcfg ProviderConf) isConnectionTypeLocal() bool {
+	pcfg.mx.Lock()
+	defer pcfg.mx.Unlock()
+
+	log.Printf("[DEBUG] Getting connection type")
+	connType := false
+	if runtime.GOOS == "windows" {
+		if pcfg.Configuration.WinRMHost == "" && pcfg.Configuration.WinRMUsername == "" && pcfg.Configuration.WinRMPassword == "" {
+			log.Printf("[DEBUG] Matching criteria for local execution")
+			connType = true
+		}
+	}
+	log.Printf("[DEBUG] Is connection type local ? %t", connType)
+	return connType
 }
 
 func initProviderConfig(d *schema.ResourceData) (interface{}, error) {

--- a/ad/resource_ad_computer.go
+++ b/ad/resource_ad_computer.go
@@ -61,13 +61,15 @@ func resourceADComputerRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
+
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
 		return err
 	}
 	defer meta.(ProviderConf).ReleaseWinRMClient(client)
 
-	computer, err := winrmhelper.NewComputerFromHost(client, d.Id())
+	computer, err := winrmhelper.NewComputerFromHost(client, d.Id(), isLocal)
 	if err != nil {
 		if strings.Contains(err.Error(), "ObjectNotFound") {
 			// Resource no longer exists
@@ -87,6 +89,7 @@ func resourceADComputerRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceADComputerCreate(d *schema.ResourceData, meta interface{}) error {
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
 		return err
@@ -95,7 +98,7 @@ func resourceADComputerCreate(d *schema.ResourceData, meta interface{}) error {
 
 	computer := winrmhelper.NewComputerFromResource(d)
 
-	guid, err := computer.Create(client)
+	guid, err := computer.Create(client, isLocal)
 	if err != nil {
 		return fmt.Errorf("error while creating new computer object: %s", err)
 	}
@@ -104,6 +107,7 @@ func resourceADComputerCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceADComputerUpdate(d *schema.ResourceData, meta interface{}) error {
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
 		return err
@@ -119,7 +123,7 @@ func resourceADComputerUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	err = computer.Update(client, changes)
+	err = computer.Update(client, changes, isLocal)
 	if err != nil {
 		return fmt.Errorf("error while updating computer with id %q: %s", d.Id(), err)
 	}
@@ -130,6 +134,7 @@ func resourceADComputerDelete(d *schema.ResourceData, meta interface{}) error {
 	if d.Id() == "" {
 		return nil
 	}
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
 		return err
@@ -137,7 +142,7 @@ func resourceADComputerDelete(d *schema.ResourceData, meta interface{}) error {
 	defer meta.(ProviderConf).ReleaseWinRMClient(client)
 
 	computer := winrmhelper.NewComputerFromResource(d)
-	err = computer.Delete(client)
+	err = computer.Delete(client, isLocal)
 	if err != nil {
 		return fmt.Errorf("error while deleting a computer object with id %q: %s", d.Id(), err)
 	}

--- a/ad/resource_ad_computer_test.go
+++ b/ad/resource_ad_computer_test.go
@@ -100,7 +100,7 @@ func testAccResourceADComputerExists(resource, name string, expected bool) resou
 		defer testAccProvider.Meta().(ProviderConf).ReleaseWinRMClient(client)
 
 		guid := rs.Primary.ID
-		computer, err := winrmhelper.NewComputerFromHost(client, guid)
+		computer, err := winrmhelper.NewComputerFromHost(client, guid, false)
 		if err != nil {
 			if strings.Contains(err.Error(), "ObjectNotFound") && !expected {
 				return nil

--- a/ad/resource_ad_gplink.go
+++ b/ad/resource_ad_gplink.go
@@ -63,6 +63,7 @@ func resourceADGPLink() *schema.Resource {
 }
 
 func resourceADGPLinkRead(d *schema.ResourceData, meta interface{}) error {
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
 		return err
@@ -73,7 +74,7 @@ func resourceADGPLinkRead(d *schema.ResourceData, meta interface{}) error {
 	if len(idParts) != 2 {
 		return fmt.Errorf("malformed ID for GPLink resource with ID %q", d.Id())
 	}
-	gplink, err := winrmhelper.GetGPLinkFromHost(client, idParts[0], idParts[1])
+	gplink, err := winrmhelper.GetGPLinkFromHost(client, idParts[0], idParts[1], isLocal)
 	if err != nil {
 		if strings.Contains(err.Error(), "did not find") {
 			d.SetId("")
@@ -92,6 +93,7 @@ func resourceADGPLinkRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceADGPLinkCreate(d *schema.ResourceData, meta interface{}) error {
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
 		return err
@@ -99,7 +101,7 @@ func resourceADGPLinkCreate(d *schema.ResourceData, meta interface{}) error {
 	defer meta.(ProviderConf).ReleaseWinRMClient(client)
 
 	gplink := winrmhelper.GetGPLinkFromResource(d)
-	gpLinkID, err := gplink.NewGPLink(client)
+	gpLinkID, err := gplink.NewGPLink(client, isLocal)
 	if err != nil {
 		return fmt.Errorf("while creating GPLink resource: %s", err)
 	}
@@ -109,6 +111,7 @@ func resourceADGPLinkCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceADGPLinkUpdate(d *schema.ResourceData, meta interface{}) error {
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
 		return err
@@ -123,7 +126,7 @@ func resourceADGPLinkUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 	gplink := winrmhelper.GetGPLinkFromResource(d)
-	err = gplink.ModifyGPLink(client, changes)
+	err = gplink.ModifyGPLink(client, changes, isLocal)
 	if err != nil {
 		return fmt.Errorf("while modifying GPLink with id %q: %s", d.Id(), err)
 	}
@@ -132,6 +135,7 @@ func resourceADGPLinkUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceADGPLinkDelete(d *schema.ResourceData, meta interface{}) error {
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
 		return err
@@ -139,7 +143,7 @@ func resourceADGPLinkDelete(d *schema.ResourceData, meta interface{}) error {
 	defer meta.(ProviderConf).ReleaseWinRMClient(client)
 
 	gplink := winrmhelper.GetGPLinkFromResource(d)
-	err = gplink.RemoveGPLink(client)
+	err = gplink.RemoveGPLink(client, isLocal)
 	if err != nil {
 		return fmt.Errorf("while deleting resource with ID %q: %s", d.Id(), err)
 	}

--- a/ad/resource_ad_gplink_test.go
+++ b/ad/resource_ad_gplink_test.go
@@ -146,7 +146,7 @@ func testAccResourceADGPLinkExists(resourceName string, order int, enforced, ena
 		if len(idParts) != 2 {
 			return fmt.Errorf("malformed ID for GPLink resource with ID %q", id)
 		}
-		gplink, err := winrmhelper.GetGPLinkFromHost(client, idParts[0], idParts[1])
+		gplink, err := winrmhelper.GetGPLinkFromHost(client, idParts[0], idParts[1], false)
 		if err != nil {
 			// Check that the err is really because the GPO was not found
 			// and not because of other issues

--- a/ad/resource_ad_gpo.go
+++ b/ad/resource_ad_gpo.go
@@ -54,6 +54,7 @@ func resourceADGPO() *schema.Resource {
 }
 
 func resourceADGPOCreate(d *schema.ResourceData, meta interface{}) error {
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 	g := winrmhelper.GetGPOFromResource(d)
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
@@ -61,7 +62,7 @@ func resourceADGPOCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 	defer meta.(ProviderConf).ReleaseWinRMClient(client)
 
-	guid, err := g.NewGPO(client)
+	guid, err := g.NewGPO(client, isLocal)
 	if err != nil {
 		return err
 	}
@@ -73,13 +74,14 @@ func resourceADGPORead(d *schema.ResourceData, meta interface{}) error {
 	if d.Id() == "" {
 		return nil
 	}
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
 		return err
 	}
 	defer meta.(ProviderConf).ReleaseWinRMClient(client)
 
-	g, err := winrmhelper.GetGPOFromHost(client, "", d.Id())
+	g, err := winrmhelper.GetGPOFromHost(client, "", d.Id(), isLocal)
 	if err != nil {
 		if strings.Contains(err.Error(), "GpoWithNameNotFound") || strings.Contains(err.Error(), "GpoWithIdNotFound") {
 			d.SetId("")
@@ -96,6 +98,7 @@ func resourceADGPORead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceADGPOUpdate(d *schema.ResourceData, meta interface{}) error {
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
 		return err
@@ -103,7 +106,7 @@ func resourceADGPOUpdate(d *schema.ResourceData, meta interface{}) error {
 	defer meta.(ProviderConf).ReleaseWinRMClient(client)
 
 	g := winrmhelper.GetGPOFromResource(d)
-	_, err = g.UpdateGPO(client, d)
+	_, err = g.UpdateGPO(client, d, isLocal)
 	if err != nil {
 		return err
 	}
@@ -111,6 +114,7 @@ func resourceADGPOUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceADGPODelete(d *schema.ResourceData, meta interface{}) error {
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
 		return err
@@ -118,7 +122,7 @@ func resourceADGPODelete(d *schema.ResourceData, meta interface{}) error {
 	defer meta.(ProviderConf).ReleaseWinRMClient(client)
 
 	g := winrmhelper.GetGPOFromResource(d)
-	err = g.DeleteGPO(client)
+	err = g.DeleteGPO(client, isLocal)
 	if err != nil {
 		return err
 	}

--- a/ad/resource_ad_gpo_security_test.go
+++ b/ad/resource_ad_gpo_security_test.go
@@ -48,7 +48,7 @@ func testAccResourceADGPOSecurityExists(resourceName string, desired bool) resou
 			return err
 		}
 		defer testAccProvider.Meta().(ProviderConf).ReleaseWinRMClient(client)
-		gpo, err := winrmhelper.GetGPOFromHost(client, "", guid)
+		gpo, err := winrmhelper.GetGPOFromHost(client, "", guid, false)
 		if err != nil {
 			// if the GPO got destroyed first then the rest of the entities depending on it
 			// are also destroyed.
@@ -58,7 +58,7 @@ func testAccResourceADGPOSecurityExists(resourceName string, desired bool) resou
 			return err
 		}
 
-		_, err = winrmhelper.GetSecIniFromHost(client, gpo)
+		_, err = winrmhelper.GetSecIniFromHost(client, gpo, false)
 		if err != nil {
 			if !desired && strings.Contains(err.Error(), "NotFound") {
 				return nil

--- a/ad/resource_ad_gpo_test.go
+++ b/ad/resource_ad_gpo_test.go
@@ -74,7 +74,7 @@ func testAccResourceADGPOExists(resourceName, name string, expected bool) resour
 			return err
 		}
 		defer testAccProvider.Meta().(ProviderConf).ReleaseWinRMClient(client)
-		gpo, err := winrmhelper.GetGPOFromHost(client, "", guid)
+		gpo, err := winrmhelper.GetGPOFromHost(client, "", guid, false)
 		if err != nil {
 			// Check that the err is really because the GPO was not found
 			// and not because of other issues

--- a/ad/resource_ad_group_membership.go
+++ b/ad/resource_ad_group_membership.go
@@ -38,6 +38,7 @@ func resourceADGroupMembership() *schema.Resource {
 }
 
 func resourceADGroupMembershipRead(d *schema.ResourceData, meta interface{}) error {
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
 		return err
@@ -46,7 +47,7 @@ func resourceADGroupMembershipRead(d *schema.ResourceData, meta interface{}) err
 
 	toks := strings.Split(d.Id(), "_")
 
-	gm, err := winrmhelper.NewGroupMembershipFromHost(client, toks[0])
+	gm, err := winrmhelper.NewGroupMembershipFromHost(client, toks[0], isLocal)
 	if err != nil {
 		return err
 	}
@@ -61,6 +62,7 @@ func resourceADGroupMembershipRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceADGroupMembershipCreate(d *schema.ResourceData, meta interface{}) error {
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
 		return err
@@ -72,7 +74,7 @@ func resourceADGroupMembershipCreate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	err = gm.Create(client)
+	err = gm.Create(client, isLocal)
 	if err != nil {
 		return err
 	}
@@ -89,6 +91,7 @@ func resourceADGroupMembershipCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceADGroupMembershipUpdate(d *schema.ResourceData, meta interface{}) error {
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
 		return err
@@ -100,7 +103,7 @@ func resourceADGroupMembershipUpdate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	err = gm.Update(client, gm.GroupMembers)
+	err = gm.Update(client, gm.GroupMembers, isLocal)
 	if err != nil {
 		return err
 	}
@@ -109,6 +112,7 @@ func resourceADGroupMembershipUpdate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceADGroupMembershipDelete(d *schema.ResourceData, meta interface{}) error {
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
 		return err
@@ -120,7 +124,7 @@ func resourceADGroupMembershipDelete(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	err = gm.Delete(client)
+	err = gm.Delete(client, isLocal)
 	if err != nil {
 		return err
 	}

--- a/ad/resource_ad_group_membership_test.go
+++ b/ad/resource_ad_group_membership_test.go
@@ -63,7 +63,7 @@ func testAccADGroupMembershipExists(resourceName string, expected bool, desiredM
 		}
 		defer testAccProvider.Meta().(ProviderConf).ReleaseWinRMClient(client)
 		toks := strings.Split(rs.Primary.ID, "_")
-		gm, err := winrmhelper.NewGroupMembershipFromHost(client, toks[0])
+		gm, err := winrmhelper.NewGroupMembershipFromHost(client, toks[0], false)
 		if err != nil {
 			if strings.Contains(err.Error(), "ADIdentityNotFoundException") && !expected {
 				return nil

--- a/ad/resource_ad_group_test.go
+++ b/ad/resource_ad_group_test.go
@@ -63,7 +63,7 @@ func testAccGroupExists(name, domain, groupSAM string, expected bool) resource.T
 			return err
 		}
 		defer testAccProvider.Meta().(ProviderConf).ReleaseWinRMClient(client)
-		u, err := winrmhelper.GetGroupFromHost(client, rs.Primary.ID)
+		u, err := winrmhelper.GetGroupFromHost(client, rs.Primary.ID, false)
 		if err != nil {
 			if strings.Contains(err.Error(), "ADIdentityNotFoundException") && !expected {
 				return nil

--- a/ad/resource_ad_ou.go
+++ b/ad/resource_ad_ou.go
@@ -58,6 +58,7 @@ func resourceADOURead(d *schema.ResourceData, meta interface{}) error {
 	if d.Id() == "" {
 		return nil
 	}
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
@@ -65,7 +66,7 @@ func resourceADOURead(d *schema.ResourceData, meta interface{}) error {
 	}
 	defer meta.(ProviderConf).ReleaseWinRMClient(client)
 
-	ou, err := winrmhelper.NewOrgUnitFromHost(client, d.Id(), "", "")
+	ou, err := winrmhelper.NewOrgUnitFromHost(client, d.Id(), "", "", isLocal)
 	if err != nil {
 		if strings.Contains(err.Error(), "ObjectNotFound") {
 			// Resource no longer exists
@@ -86,6 +87,7 @@ func resourceADOURead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceADOUCreate(d *schema.ResourceData, meta interface{}) error {
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
 		return err
@@ -93,7 +95,7 @@ func resourceADOUCreate(d *schema.ResourceData, meta interface{}) error {
 	defer meta.(ProviderConf).ReleaseWinRMClient(client)
 
 	ou := winrmhelper.NewOrgUnitFromResource(d)
-	guid, err := ou.Create(client)
+	guid, err := ou.Create(client, isLocal)
 	if err != nil {
 		return err
 	}
@@ -103,6 +105,7 @@ func resourceADOUCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceADOUUpdate(d *schema.ResourceData, meta interface{}) error {
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
 		return err
@@ -119,7 +122,7 @@ func resourceADOUUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	err = ou.Update(client, changes)
+	err = ou.Update(client, changes, isLocal)
 	if err != nil {
 		return err
 	}
@@ -127,6 +130,7 @@ func resourceADOUUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceADOUDelete(d *schema.ResourceData, meta interface{}) error {
+	isLocal := meta.(ProviderConf).isConnectionTypeLocal()
 	client, err := meta.(ProviderConf).AcquireWinRMClient()
 	if err != nil {
 		return err
@@ -134,7 +138,7 @@ func resourceADOUDelete(d *schema.ResourceData, meta interface{}) error {
 	defer meta.(ProviderConf).ReleaseWinRMClient(client)
 
 	ou := winrmhelper.NewOrgUnitFromResource(d)
-	err = ou.Delete(client)
+	err = ou.Delete(client, isLocal)
 	if err != nil {
 		return err
 	}

--- a/ad/resource_ad_ou_test.go
+++ b/ad/resource_ad_ou_test.go
@@ -73,7 +73,7 @@ func testAccResourceADOUExists(resource, name string, expected bool) resource.Te
 		}
 		defer testAccProvider.Meta().(ProviderConf).ReleaseWinRMClient(client)
 		guid := rs.Primary.ID
-		ou, err := winrmhelper.NewOrgUnitFromHost(client, guid, "", "")
+		ou, err := winrmhelper.NewOrgUnitFromHost(client, guid, "", "", false)
 		if err != nil {
 			if strings.Contains(err.Error(), "ObjectNotFound") && !expected {
 				return nil

--- a/ad/resource_ad_user_test.go
+++ b/ad/resource_ad_user_test.go
@@ -309,7 +309,7 @@ func retrieveADUserFromRunningState(name, domain string, s *terraform.State, att
 	}
 	defer testAccProvider.Meta().(ProviderConf).ReleaseWinRMClient(client)
 
-	u, err := winrmhelper.GetUserFromHost(client, rs.Primary.ID, attributeList)
+	u, err := winrmhelper.GetUserFromHost(client, rs.Primary.ID, attributeList, false)
 
 	return u, err
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,26 @@ where `YOURDOMAIN.COM` is the value of the `krb_realm` setting, and 192.168.1.12
 `Basic` remains the default authentication method, although this may change in the future. The provider will use
 Kerberos as its authentication when `krb_realm` is set.
 
+## Note about Local execution (Windows only)
+
+It is possible to execute commands locally if the OS on which terraform is running is Windows.
+In such case, your need to put the following settings in the provider configuration :
+
+- Set winrm_username to null
+- Set winrm_password to null
+- Set winrm_hostname to null
+
+Note: it will set to local only if all 3 parameters are set to null 
+
+### Example
+```terraform
+provider "ad" {
+  winrm_hostname = ""
+  winrm_username = ""
+  winrm_password = ""
+}
+```
+
 ## Example Usage
 
 ```terraform

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,29 +61,64 @@ provider "ad" {
 }
 ```
 
+ ## Example Usage
+ 
+ ```terraform
+
 ## Example Usage
 
 ```terraform
-resource "ad_ou" "o" { 
-    name = "gplinktestOU"
-    path = "dc=yourdomain,dc=com"
-    description = "OU for gplink tests"
-    protected = false
-}
-    
-resource "ad_gpo" "g" {
-    name        = "gplinktestGPO"
-    domain      = "yourdomain.com"
-    description = "gpo for gplink tests"
-    status      = "AllSettingsEnabled"
+variable "hostname" { default = "ad.yourdomain.com" }
+variable "username" { default = "user" }
+variable "password" { default = "password" }
+
+// remote using Basic authentication
+provider "ad" {
+  winrm_hostname = var.hostname
+  winrm_username = var.username
+  winrm_password = var.password
 }
 
-resource "ad_gplink" "og" { 
-    gpo_guid = ad_gpo.g.id
-    target_dn = ad_ou.o.dn
-    enforced = true
-    enabled = true
-    order = 0
+// remote using NTLM authentication
+provider "ad" {
+  winrm_hostname = var.hostname
+  winrm_username = var.username
+  winrm_password = var.password
+  winrm_use_ntlm = true
+}
+
+// remote using NTLM authentication and HTTPS
+provider "ad" {
+  winrm_hostname = var.hostname
+  winrm_username = var.username
+  winrm_password = var.password
+  winrm_use_ntlm = true
+  winrm_port     = 5986
+  winrm_proto    = "https"
+  winrm_insecure = true
+}
+
+// remote using Kerberos authentication
+provider "ad" {
+  winrm_hostname = var.hostname
+  winrm_username = var.username
+  winrm_password = var.password
+  krb_realm      = "YOURDOMAIN.COM"
+}
+
+// remote using Kerberos authentication with krb5.conf file
+provider "ad" {
+  winrm_hostname = var.hostname
+  winrm_username = var.username
+  winrm_password = var.password
+  krb_conf       = "/etc/krb5.conf"
+}
+
+// local (windows only)
+provider "ad" {
+  winrm_hostname = ""
+  winrm_username = ""
+  winrm_password = ""
 }
 ```
 
@@ -101,6 +136,6 @@ resource "ad_gplink" "og" {
 - **krb_realm** (String, Optional) The name of the kerberos realm (domain) we will use for authentication. (default: "", environment variable: AD_KRB_REALM)
 - **krb_spn** (String, Optional) Alternative Service Principal Name. (default: none, environment variable: AD_KRB_SPN)
 - **winrm_insecure** (Boolean, Optional) Trust unknown certificates. (default: false, environment variable: AD_WINRM_INSECURE)
-- **winrm_use_ntlm** (Boolean, Optional) Use NTLM authentication. (default: false, environment variable: AD_WINRM_USE_NTLM)
 - **winrm_port** (Number, Optional) The port WinRM is listening for connections. (default: 5985, environment variable: AD_PORT)
 - **winrm_proto** (String, Optional) The WinRM protocol we will use. (default: http, environment variable: AD_PROTO)
+- **winrm_use_ntlm** (Boolean, Optional) Use NTLM authentication. (default: false, environment variable: AD_WINRM_USE_NTLM)

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ In such case, your need to put the following settings in the provider configurat
 - Set winrm_password to null
 - Set winrm_hostname to null
 
-Note: it will set to local only if all 3 parameters are set to null 
+Note: it will set to local only `if all 3 parameters are set to null`
 
 ### Example
 ```terraform

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,21 +1,52 @@
-resource "ad_ou" "o" { 
-    name = "gplinktestOU"
-    path = "dc=yourdomain,dc=com"
-    description = "OU for gplink tests"
-    protected = false
-}
-    
-resource "ad_gpo" "g" {
-    name        = "gplinktestGPO"
-    domain      = "yourdomain.com"
-    description = "gpo for gplink tests"
-    status      = "AllSettingsEnabled"
+variable "hostname" { default = "ad.yourdomain.com" }
+variable "username" { default = "user" }
+variable "password" { default = "password" }
+
+// remote using Basic authentication
+provider "ad" {
+  winrm_hostname = var.hostname
+  winrm_username = var.username
+  winrm_password = var.password
 }
 
-resource "ad_gplink" "og" { 
-    gpo_guid = ad_gpo.g.id
-    target_dn = ad_ou.o.dn
-    enforced = true
-    enabled = true
-    order = 0
+// remote using NTLM authentication
+provider "ad" {
+  winrm_hostname = var.hostname
+  winrm_username = var.username
+  winrm_password = var.password
+  winrm_use_ntlm = true
+}
+
+// remote using NTLM authentication and HTTPS 
+provider "ad" {
+  winrm_hostname = var.hostname
+  winrm_username = var.username
+  winrm_password = var.password
+  winrm_use_ntlm = true
+  winrm_port     = 5986
+  winrm_proto    = "https"
+  winrm_insecure = true
+}
+
+// remote using Kerberos authentication  
+provider "ad" {
+  winrm_hostname = var.hostname
+  winrm_username = var.username
+  winrm_password = var.password
+  krb_realm      = "YOURDOMAIN.COM"
+}
+
+// remote using Kerberos authentication with krb5.conf file
+provider "ad" {
+  winrm_hostname = var.hostname
+  winrm_username = var.username
+  winrm_password = var.password
+  krb_conf       = "/etc/krb5.conf"
+}
+
+// local (windows only)
+provider "ad" {
+  winrm_hostname = ""
+  winrm_username = ""
+  winrm_password = ""
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -17,7 +17,7 @@ provider "ad" {
   winrm_use_ntlm = true
 }
 
-// remote using NTLM authentication and HTTPS 
+// remote using NTLM authentication and HTTPS
 provider "ad" {
   winrm_hostname = var.hostname
   winrm_username = var.username
@@ -28,7 +28,7 @@ provider "ad" {
   winrm_insecure = true
 }
 
-// remote using Kerberos authentication  
+// remote using Kerberos authentication
 provider "ad" {
   winrm_hostname = var.hostname
   winrm_username = var.username

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -41,6 +41,30 @@ where `YOURDOMAIN.COM` is the value of the `krb_realm` setting, and 192.168.1.12
 `Basic` remains the default authentication method, although this may change in the future. The provider will use
 Kerberos as its authentication when `krb_realm` is set.
 
+## Note about Local execution (Windows only)
+
+It is possible to execute commands locally if the OS on which terraform is running is Windows.
+In such case, your need to put the following settings in the provider configuration :
+
+- Set winrm_username to null
+- Set winrm_password to null
+- Set winrm_hostname to null
+
+Note: it will set to local only `if all 3 parameters are set to null`
+
+### Example
+```terraform
+provider "ad" {
+  winrm_hostname = ""
+  winrm_username = ""
+  winrm_password = ""
+}
+```
+
+ ## Example Usage
+ 
+ ```terraform
+
 ## Example Usage
 
 {{tffile "examples/provider/provider.tf"}}


### PR DESCRIPTION
### Description

- Implement the possibility to run powershell commands locally (not via winrm) if the operating system is windows and no credentials are set in the provider configuration

- Add examples in documentation regarding provider configuration

(Once again I apologies for not adding tests, I'm still not familiar with how to implement those.)

### References

https://github.com/hashicorp/terraform-provider-ad/issues/70

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
