### PR TITLE
Allow dependabot to check github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "gomod"
     vendor: "true"
     directory: "/"


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

This change allows dependabot to check any GitHub action which this project uses on a weekly basis and submit pull requests with version bumps in order to keep packages up-to-date.

### References
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
