### PR TITLE
Fix formatting issues in docs/index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -62,10 +62,6 @@ provider "ad" {
 ```
 
  ## Example Usage
- 
- ```terraform
-
-## Example Usage
 
 ```terraform
 variable "hostname" { default = "ad.yourdomain.com" }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -62,10 +62,6 @@ provider "ad" {
 ```
 
  ## Example Usage
- 
- ```terraform
-
-## Example Usage
 
 {{tffile "examples/provider/provider.tf"}}
 


### PR DESCRIPTION
### Description

Removed a couple duplicate lines from `docs/index.md` that was causing the code formatting in "Example Usage" to terminate prematurely in some renderings (e.g: https://registry.terraform.io/providers/hashicorp/ad/latest/docs )

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
