### PR TITLE
[Issue-111] fix-cmd-modify-name

### DIFF
--- a/ad/internal/winrmhelper/winrm_group.go
+++ b/ad/internal/winrmhelper/winrm_group.go
@@ -95,7 +95,7 @@ func (g *Group) ModifyGroup(d *schema.ResourceData, client *winrm.Client, execLo
 
 	if d.HasChange("name") {
 		cmds := fmt.Sprintf("Rename-ADObject -Identity %q -NewName %q", g.GUID, d.Get("name").(string))
-		result, err := RunWinRMCommand(client, []string{cmd}, false, false, execLocally)
+		result, err := RunWinRMCommand(client, []string{cmds}, false, false, execLocally)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Description

Fixing the update of the name in ad_group resource.
cmd executed was not taking variables into account due to a sprintf statement missing

### References
https://github.com/hashicorp/terraform-provider-ad/issues/111

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
