### PR TITLE
solve error when creating multiple AD Users

### DIFF
--- a/ad/internal/winrmhelper/powershell_command.go
+++ b/ad/internal/winrmhelper/powershell_command.go
@@ -95,8 +95,7 @@ func (p *PSCommand) Run(conf *config.ProviderConf) (*PSCommandResult, error) {
 	if err != nil {
 		return nil, fmt.Errorf("while acquiring winrm client: %s", err)
 	}
-	defer conf.ReleaseWinRMClient(conn)
-
+	
 	encodedCmd := winrm.Powershell(p.cmd)
 
 	if !p.ExecLocally && conn != nil {
@@ -109,6 +108,7 @@ func (p *PSCommand) Run(conf *config.ProviderConf) (*PSCommandResult, error) {
 		log.Printf("[DEBUG] Executing command on local host")
 		stdout, stderr, res, err = localShell.ExecutePScmd(encodedCmd)
 	}
+	defer conf.ReleaseWinRMClient(conn)
 
 	if err != nil {
 		log.Printf("[DEBUG] run error : %s", err)


### PR DESCRIPTION
### Description

Solves the error occurred when creating multiple users i.e., `stderr: New-ADUser : A local error has occurredAt`. 
Idea - Release the client after execution of PS Command. 
Tested by creating 100 users.

### References
https://github.com/hashicorp/terraform-provider-ad/issues/119

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
