### PR TITLE
Add name property to set the AD object name

### DIFF
--- a/ad/data_source_ad_user.go
+++ b/ad/data_source_ad_user.go
@@ -20,6 +20,11 @@ func dataSourceADUser() *schema.Resource {
 				Required:    true,
 				Description: "The user's identifier. It can be the group's GUID, SID, Distinguished Name, or SAM Account Name.",
 			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the user object.",
+			},
 			"sam_account_name": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -204,6 +209,7 @@ func dataSourceADUserRead(d *schema.ResourceData, meta interface{}) error {
 	if u == nil {
 		return fmt.Errorf("No user found with user_id %q", userID)
 	}
+	_ = d.Set("name", u.Name)
 	_ = d.Set("sam_account_name", u.SAMAccountName)
 	_ = d.Set("display_name", u.DisplayName)
 	_ = d.Set("principal_name", u.PrincipalName)

--- a/ad/resource_ad_user.go
+++ b/ad/resource_ad_user.go
@@ -26,6 +26,12 @@ func resourceADUser() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The Name of an Active Directory user.",
+			},
 			"display_name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -304,6 +310,7 @@ func resourceADUserRead(d *schema.ResourceData, meta interface{}) error {
 		d.SetId("")
 		return nil
 	}
+	_ = d.Set("name", u.Name)
 	_ = d.Set("sam_account_name", u.SAMAccountName)
 	_ = d.Set("display_name", u.DisplayName)
 	_ = d.Set("principal_name", u.PrincipalName)


### PR DESCRIPTION
### Description

Right now the AD object name for an `ad_user` resource is always set to the sAMAccountName value, add the ability to set this independently.

### References

- #129 

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
