### PR TITLE
Minor Change - New Functionality - Ability to Specify a Domain Controller

### DIFF
--- a/ad/internal/config/config.go
+++ b/ad/internal/config/config.go
@@ -38,6 +38,7 @@ type Settings struct {
 	WinRMUseNTLM         bool
 	WinRMPassCredentials bool
 	DomainName           string
+	DomainController     string
 }
 
 // NewConfig returns a new Config struct populated with Resource Data.
@@ -54,6 +55,7 @@ func NewConfig(d *schema.ResourceData) (*Settings, error) {
 	krbSpn := d.Get("krb_spn").(string)
 	winRMUseNTLM := d.Get("winrm_use_ntlm").(bool)
 	winRMPassCredentials := d.Get("winrm_pass_credentials").(bool)
+	domainController := d.Get("domain_controller").(string)
 
 	cfg := &Settings{
 		DomainName:           krbRealm,
@@ -68,6 +70,7 @@ func NewConfig(d *schema.ResourceData) (*Settings, error) {
 		KrbSpn:               krbSpn,
 		WinRMUseNTLM:         winRMUseNTLM,
 		WinRMPassCredentials: winRMPassCredentials,
+		DomainController:     domainController,
 	}
 
 	return cfg, nil
@@ -363,4 +366,15 @@ func (pcfg *ProviderConf) IsPassCredentialsEnabled() bool {
 	}
 	log.Printf("[DEBUG] Pass Credentials ? %t", isPassCredentialsEnabled)
 	return isPassCredentialsEnabled
+}
+
+// If a
+func (pcfg *ProviderConf) IdentifyDomainController() string {
+	log.Printf("[DEBUG] Checking to see if a domain controller was specified.")
+	if pcfg.Settings.DomainController != "" {
+		log.Printf("[DEBUG] Using specified domain controller for PowerShell commands.")
+		return pcfg.Settings.DomainController
+	}
+	log.Printf("[DEBUG] Using the domain name instead of a specific domain controller for PowerShell commands.")
+	return pcfg.Settings.DomainName
 }

--- a/ad/internal/winrmhelper/winrm_computer.go
+++ b/ad/internal/winrmhelper/winrm_computer.go
@@ -50,7 +50,7 @@ func NewComputerFromHost(conf *config.ProviderConf, identity string) (*Computer,
 		PassCredentials: conf.IsPassCredentialsEnabled(),
 		Username:        conf.Settings.WinRMUsername,
 		Password:        conf.Settings.WinRMPassword,
-		Server:          conf.Settings.DomainName,
+		Server:          conf.IdentifyDomainController(),
 	}
 	psCmd := NewPSCommand([]string{cmd}, psOpts)
 	result, err := psCmd.Run(conf)
@@ -96,7 +96,7 @@ func (m *Computer) Create(conf *config.ProviderConf) (string, error) {
 		PassCredentials: conf.IsPassCredentialsEnabled(),
 		Username:        conf.Settings.WinRMUsername,
 		Password:        conf.Settings.WinRMPassword,
-		Server:          conf.Settings.DomainName,
+		Server:          conf.IdentifyDomainController(),
 	}
 	psCmd := NewPSCommand([]string{cmd}, psOpts)
 	result, err := psCmd.Run(conf)
@@ -135,7 +135,7 @@ func (m *Computer) Update(conf *config.ProviderConf, changes map[string]interfac
 			PassCredentials: conf.IsPassCredentialsEnabled(),
 			Username:        conf.Settings.WinRMUsername,
 			Password:        conf.Settings.WinRMPassword,
-			Server:          conf.Settings.DomainName,
+			Server:          conf.IdentifyDomainController(),
 		}
 		psCmd := NewPSCommand([]string{cmd}, psOpts)
 		result, err := psCmd.Run(conf)
@@ -166,7 +166,7 @@ func (m *Computer) Update(conf *config.ProviderConf, changes map[string]interfac
 			PassCredentials: conf.IsPassCredentialsEnabled(),
 			Username:        conf.Settings.WinRMUsername,
 			Password:        conf.Settings.WinRMPassword,
-			Server:          conf.Settings.DomainName,
+			Server:          conf.IdentifyDomainController(),
 		}
 		psCmd := NewPSCommand([]string{cmd}, psOpts)
 		result, err := psCmd.Run(conf)
@@ -196,7 +196,7 @@ func (m *Computer) Delete(conf *config.ProviderConf) error {
 		PassCredentials: conf.IsPassCredentialsEnabled(),
 		Username:        conf.Settings.WinRMUsername,
 		Password:        conf.Settings.WinRMPassword,
-		Server:          conf.Settings.DomainName,
+		Server:          conf.IdentifyDomainController(),
 	}
 	psCmd := NewPSCommand([]string{cmd}, psOpts)
 	result, err := psCmd.Run(conf)

--- a/ad/internal/winrmhelper/winrm_gplink.go
+++ b/ad/internal/winrmhelper/winrm_gplink.go
@@ -193,7 +193,7 @@ func GetGPLinkFromHost(conf *config.ProviderConf, gpoGUID, containerGUID string)
 		PassCredentials: conf.IsPassCredentialsEnabled(),
 		Username:        conf.Settings.WinRMUsername,
 		Password:        conf.Settings.WinRMPassword,
-		Server:          conf.Settings.DomainName,
+		Server:          conf.IdentifyDomainController(),
 	}
 	psCmd := NewPSCommand(cmds, psOpts)
 	result, err := psCmd.Run(conf)

--- a/ad/internal/winrmhelper/winrm_gpo.go
+++ b/ad/internal/winrmhelper/winrm_gpo.go
@@ -388,7 +388,7 @@ func (g *GPO) SetADGPOVersions(conf *config.ProviderConf, gpoVersion uint32) err
 		PassCredentials: conf.IsPassCredentialsEnabled(),
 		Username:        conf.Settings.WinRMUsername,
 		Password:        conf.Settings.WinRMPassword,
-		Server:          conf.Settings.DomainName,
+		Server:          conf.IdentifyDomainController(),
 		SkipCredPrefix:  true,
 	}
 

--- a/ad/internal/winrmhelper/winrm_group.go
+++ b/ad/internal/winrmhelper/winrm_group.go
@@ -45,7 +45,7 @@ func (g *Group) AddGroup(conf *config.ProviderConf) (string, error) {
 		PassCredentials: conf.IsPassCredentialsEnabled(),
 		Username:        conf.Settings.WinRMUsername,
 		Password:        conf.Settings.WinRMPassword,
-		Server:          conf.Settings.DomainName,
+		Server:          conf.IdentifyDomainController(),
 	}
 	psCmd := NewPSCommand(cmds, psOpts)
 	result, err := psCmd.Run(conf)
@@ -100,7 +100,7 @@ func (g *Group) ModifyGroup(d *schema.ResourceData, conf *config.ProviderConf) e
 			PassCredentials: conf.IsPassCredentialsEnabled(),
 			Username:        conf.Settings.WinRMUsername,
 			Password:        conf.Settings.WinRMPassword,
-			Server:          conf.Settings.DomainName,
+			Server:          conf.IdentifyDomainController(),
 		}
 		psCmd := NewPSCommand(cmds, psOpts)
 		result, err := psCmd.Run(conf)
@@ -122,7 +122,7 @@ func (g *Group) ModifyGroup(d *schema.ResourceData, conf *config.ProviderConf) e
 			PassCredentials: conf.IsPassCredentialsEnabled(),
 			Username:        conf.Settings.WinRMUsername,
 			Password:        conf.Settings.WinRMPassword,
-			Server:          conf.Settings.DomainName,
+			Server:          conf.IdentifyDomainController(),
 		}
 		psCmd := NewPSCommand([]string{cmd}, psOpts)
 		result, err := psCmd.Run(conf)
@@ -144,7 +144,7 @@ func (g *Group) ModifyGroup(d *schema.ResourceData, conf *config.ProviderConf) e
 			PassCredentials: conf.IsPassCredentialsEnabled(),
 			Username:        conf.Settings.WinRMUsername,
 			Password:        conf.Settings.WinRMPassword,
-			Server:          conf.Settings.DomainName,
+			Server:          conf.IdentifyDomainController(),
 		}
 		psCmd := NewPSCommand([]string{cmd}, psOpts)
 		result, err := psCmd.Run(conf)
@@ -169,7 +169,7 @@ func (g *Group) DeleteGroup(conf *config.ProviderConf) error {
 		PassCredentials: conf.IsPassCredentialsEnabled(),
 		Username:        conf.Settings.WinRMUsername,
 		Password:        conf.Settings.WinRMPassword,
-		Server:          conf.Settings.DomainName,
+		Server:          conf.IdentifyDomainController(),
 	}
 	psCmd := NewPSCommand([]string{cmd}, psOpts)
 	result, err := psCmd.Run(conf)
@@ -211,7 +211,7 @@ func GetGroupFromHost(conf *config.ProviderConf, guid string) (*Group, error) {
 		PassCredentials: conf.IsPassCredentialsEnabled(),
 		Username:        conf.Settings.WinRMUsername,
 		Password:        conf.Settings.WinRMPassword,
-		Server:          conf.Settings.DomainName,
+		Server:          conf.IdentifyDomainController(),
 	}
 	psCmd := NewPSCommand([]string{cmd}, psOpts)
 	result, err := psCmd.Run(conf)

--- a/ad/internal/winrmhelper/winrm_group_membership.go
+++ b/ad/internal/winrmhelper/winrm_group_membership.go
@@ -78,7 +78,7 @@ func (g *GroupMembership) getGroupMembers(conf *config.ProviderConf) ([]*GroupMe
 		PassCredentials: conf.IsPassCredentialsEnabled(),
 		Username:        conf.Settings.WinRMUsername,
 		Password:        conf.Settings.WinRMPassword,
-		Server:          conf.Settings.DomainName,
+		Server:          conf.IdentifyDomainController(),
 	}
 	psCmd := NewPSCommand([]string{cmd}, psOpts)
 	result, err := psCmd.Run(conf)
@@ -114,7 +114,7 @@ func (g *GroupMembership) bulkGroupMembersOp(conf *config.ProviderConf, operatio
 		PassCredentials: conf.IsPassCredentialsEnabled(),
 		Username:        conf.Settings.WinRMUsername,
 		Password:        conf.Settings.WinRMPassword,
-		Server:          conf.Settings.DomainName,
+		Server:          conf.IdentifyDomainController(),
 	}
 	psCmd := NewPSCommand([]string{cmd}, psOpts)
 	result, err := psCmd.Run(conf)
@@ -170,7 +170,7 @@ func (g *GroupMembership) Create(conf *config.ProviderConf) error {
 		PassCredentials: conf.IsPassCredentialsEnabled(),
 		Username:        conf.Settings.WinRMUsername,
 		Password:        conf.Settings.WinRMPassword,
-		Server:          conf.Settings.DomainName,
+		Server:          conf.IdentifyDomainController(),
 	}
 	psCmd := NewPSCommand(cmds, psOpts)
 	result, err := psCmd.Run(conf)
@@ -191,7 +191,7 @@ func (g *GroupMembership) Delete(conf *config.ProviderConf) error {
 		PassCredentials: conf.IsPassCredentialsEnabled(),
 		Username:        conf.Settings.WinRMUsername,
 		Password:        conf.Settings.WinRMPassword,
-		Server:          conf.Settings.DomainName,
+		Server:          conf.IdentifyDomainController(),
 		SkipCredPrefix:  true,
 	}
 	subcmd := NewPSCommand([]string{fmt.Sprintf("Get-AdGroupMember %q", g.GroupGUID)}, subCmdOpt)
@@ -204,7 +204,7 @@ func (g *GroupMembership) Delete(conf *config.ProviderConf) error {
 		PassCredentials: conf.IsPassCredentialsEnabled(),
 		Username:        conf.Settings.WinRMUsername,
 		Password:        conf.Settings.WinRMPassword,
-		Server:          conf.Settings.DomainName,
+		Server:          conf.IdentifyDomainController(),
 	}
 	psCmd := NewPSCommand([]string{cmd}, psOpts)
 	result, err := psCmd.Run(conf)

--- a/ad/internal/winrmhelper/winrm_helper.go
+++ b/ad/internal/winrmhelper/winrm_helper.go
@@ -106,7 +106,7 @@ func SetMachineExtensionNames(conf *config.ProviderConf, gpoDN, value string) er
 		PassCredentials: conf.IsPassCredentialsEnabled(),
 		Username:        conf.Settings.WinRMUsername,
 		Password:        conf.Settings.WinRMPassword,
-		Server:          conf.Settings.DomainName,
+		Server:          conf.IdentifyDomainController(),
 	}
 	psCmd := NewPSCommand([]string{cmd}, psOpts)
 	result, err := psCmd.Run(conf)

--- a/ad/internal/winrmhelper/winrm_ou.go
+++ b/ad/internal/winrmhelper/winrm_ou.go
@@ -53,7 +53,7 @@ func NewOrgUnitFromHost(conf *config.ProviderConf, guid, name, path string) (*Or
 		PassCredentials: conf.IsPassCredentialsEnabled(),
 		Username:        conf.Settings.WinRMUsername,
 		Password:        conf.Settings.WinRMPassword,
-		Server:          conf.Settings.DomainName,
+		Server:          conf.IdentifyDomainController(),
 	}
 	psCmd := NewPSCommand([]string{cmd}, psOpts)
 	result, err := psCmd.Run(conf)
@@ -97,7 +97,7 @@ func (o *OrgUnit) Create(conf *config.ProviderConf) (string, error) {
 		PassCredentials: conf.IsPassCredentialsEnabled(),
 		Username:        conf.Settings.WinRMUsername,
 		Password:        conf.Settings.WinRMPassword,
-		Server:          conf.Settings.DomainName,
+		Server:          conf.IdentifyDomainController(),
 	}
 	psCmd := NewPSCommand([]string{cmd}, psOpts)
 	result, err := psCmd.Run(conf)
@@ -141,7 +141,7 @@ func (o *OrgUnit) Update(conf *config.ProviderConf, changes map[string]interface
 			PassCredentials: conf.IsPassCredentialsEnabled(),
 			Username:        conf.Settings.WinRMUsername,
 			Password:        conf.Settings.WinRMPassword,
-			Server:          conf.Settings.DomainName,
+			Server:          conf.IdentifyDomainController(),
 		}
 		psCmd := NewPSCommand([]string{cmd}, psOpts)
 		result, err := psCmd.Run(conf)
@@ -164,7 +164,7 @@ func (o *OrgUnit) Update(conf *config.ProviderConf, changes map[string]interface
 				PassCredentials: conf.IsPassCredentialsEnabled(),
 				Username:        conf.Settings.WinRMUsername,
 				Password:        conf.Settings.WinRMPassword,
-				Server:          conf.Settings.DomainName,
+				Server:          conf.IdentifyDomainController(),
 			}
 			psCmd := NewPSCommand([]string{cmd}, psOpts)
 			result, err := psCmd.Run(conf)
@@ -185,7 +185,7 @@ func (o *OrgUnit) Update(conf *config.ProviderConf, changes map[string]interface
 			PassCredentials: conf.IsPassCredentialsEnabled(),
 			Username:        conf.Settings.WinRMUsername,
 			Password:        conf.Settings.WinRMPassword,
-			Server:          conf.Settings.DomainName,
+			Server:          conf.IdentifyDomainController(),
 		}
 		psCmd := NewPSCommand([]string{cmd}, psOpts)
 		result, err := psCmd.Run(conf)
@@ -205,7 +205,7 @@ func (o *OrgUnit) Update(conf *config.ProviderConf, changes map[string]interface
 				PassCredentials: conf.IsPassCredentialsEnabled(),
 				Username:        conf.Settings.WinRMUsername,
 				Password:        conf.Settings.WinRMPassword,
-				Server:          conf.Settings.DomainName,
+				Server:          conf.IdentifyDomainController(),
 			}
 			psCmd := NewPSCommand([]string{cmd}, psOpts)
 			result, err := psCmd.Run(conf)
@@ -227,7 +227,7 @@ func (o *OrgUnit) Update(conf *config.ProviderConf, changes map[string]interface
 			PassCredentials: conf.IsPassCredentialsEnabled(),
 			Username:        conf.Settings.WinRMUsername,
 			Password:        conf.Settings.WinRMPassword,
-			Server:          conf.Settings.DomainName,
+			Server:          conf.IdentifyDomainController(),
 		}
 		psCmd := NewPSCommand([]string{cmd}, psOpts)
 		result, err := psCmd.Run(conf)
@@ -248,7 +248,7 @@ func (o *OrgUnit) Update(conf *config.ProviderConf, changes map[string]interface
 			PassCredentials: conf.IsPassCredentialsEnabled(),
 			Username:        conf.Settings.WinRMUsername,
 			Password:        conf.Settings.WinRMPassword,
-			Server:          conf.Settings.DomainName,
+			Server:          conf.IdentifyDomainController(),
 		}
 		psCmd := NewPSCommand([]string{cmd}, psOpts)
 		result, err := psCmd.Run(conf)
@@ -281,7 +281,7 @@ func (o *OrgUnit) Delete(conf *config.ProviderConf) error {
 		PassCredentials: conf.IsPassCredentialsEnabled(),
 		Username:        conf.Settings.WinRMUsername,
 		Password:        conf.Settings.WinRMPassword,
-		Server:          conf.Settings.DomainName,
+		Server:          conf.IdentifyDomainController(),
 		SkipCredPrefix:  true,
 	}
 

--- a/ad/internal/winrmhelper/winrm_user.go
+++ b/ad/internal/winrmhelper/winrm_user.go
@@ -221,7 +221,7 @@ func (u *User) NewUser(conf *config.ProviderConf) (string, error) {
 		PassCredentials: conf.IsPassCredentialsEnabled(),
 		Username:        conf.Settings.WinRMUsername,
 		Password:        conf.Settings.WinRMPassword,
-		Server:          conf.Settings.DomainName,
+		Server:          conf.IdentifyDomainController(),
 	}
 	psCmd := NewPSCommand(cmds, psOpts)
 	result, err := psCmd.Run(conf)
@@ -392,7 +392,7 @@ func (u *User) ModifyUser(d *schema.ResourceData, conf *config.ProviderConf) err
 			PassCredentials: conf.IsPassCredentialsEnabled(),
 			Username:        conf.Settings.WinRMUsername,
 			Password:        conf.Settings.WinRMPassword,
-			Server:          conf.Settings.DomainName,
+			Server:          conf.IdentifyDomainController(),
 		}
 		psCmd := NewPSCommand(cmds, psOpts)
 		result, err := psCmd.Run(conf)
@@ -415,7 +415,7 @@ func (u *User) ModifyUser(d *schema.ResourceData, conf *config.ProviderConf) err
 			PassCredentials: conf.IsPassCredentialsEnabled(),
 			Username:        conf.Settings.WinRMUsername,
 			Password:        conf.Settings.WinRMPassword,
-			Server:          conf.Settings.DomainName,
+			Server:          conf.IdentifyDomainController(),
 		}
 		psCmd := NewPSCommand([]string{cmd}, psOpts)
 		result, err := psCmd.Run(conf)
@@ -438,7 +438,7 @@ func (u *User) ModifyUser(d *schema.ResourceData, conf *config.ProviderConf) err
 			PassCredentials: conf.IsPassCredentialsEnabled(),
 			Username:        conf.Settings.WinRMUsername,
 			Password:        conf.Settings.WinRMPassword,
-			Server:          conf.Settings.DomainName,
+			Server:          conf.IdentifyDomainController(),
 		}
 		psCmd := NewPSCommand([]string{cmd}, psOpts)
 		result, err := psCmd.Run(conf)
@@ -463,7 +463,7 @@ func (u *User) DeleteUser(conf *config.ProviderConf) error {
 		PassCredentials: conf.IsPassCredentialsEnabled(),
 		Username:        conf.Settings.WinRMUsername,
 		Password:        conf.Settings.WinRMPassword,
-		Server:          conf.Settings.DomainName,
+		Server:          conf.IdentifyDomainController(),
 	}
 	psCmd := NewPSCommand([]string{cmd}, psOpts)
 	_, err := psCmd.Run(conf)
@@ -573,7 +573,7 @@ func GetUserFromHost(conf *config.ProviderConf, guid string, customAttributes []
 		PassCredentials: conf.IsPassCredentialsEnabled(),
 		Username:        conf.Settings.WinRMUsername,
 		Password:        conf.Settings.WinRMPassword,
-		Server:          conf.Settings.DomainName,
+		Server:          conf.IdentifyDomainController(),
 	}
 	psCmd := NewPSCommand([]string{cmd}, psOpts)
 	result, err := psCmd.Run(conf)

--- a/ad/provider.go
+++ b/ad/provider.go
@@ -98,6 +98,12 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("AD_WINRM_PASS_CREDENTIALS", false),
 				Description: "Pass credentials in WinRM session to create a System.Management.Automation.PSCredential. (default: false, environment variable: AD_WINRM_PASS_CREDENTIALS)",
 			},
+			"domain_controller": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("AD_DC", ""),
+				Description: "Use a specific domain controller. (default: none, environment variable: AD_DC)",
+			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"ad_user":     dataSourceADUser(),


### PR DESCRIPTION
### Description

Right now, the AD provider assumes the KRB Realm is the server name it should interact with by using its value for the various PowerShell commands. Typically, this would be fine. But in cases where several domain controllers are load balanced, there is a chance an AD object will not synchronize between domain controllers quickly enough. So, subsequent requests might find unexpected states of AD objects if the domain controllers have not yet synchronized. AD, after all, is _eventually_ consistent. This problem worsens if some domain controllers are physically distant.

This change would make a small addition to allow users to specify a specific domain controller when desired, which overrides the "Server" or "ComputerName" flag, depending on the PowerShell command. If none is specified, the provider uses the KRB Realm as before.

I am an absolute amateur at Go development and completely new to Terraform provider development. Criticism and suggestions are more than welcome.

### References

This is in response to the bug described here, which impacted me as well: #125 

The idea is was not really my own, but a suggestion made here: #132 

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
