### PR TITLE
Update Delete function to also remove leaf objects

### DIFF
--- a/ad/internal/winrmhelper/winrm_computer.go
+++ b/ad/internal/winrmhelper/winrm_computer.go
@@ -183,7 +183,7 @@ func (m *Computer) Update(conf *config.ProviderConf, changes map[string]interfac
 
 // Delete deletes an existing Computer objects from the AD tree
 func (m *Computer) Delete(conf *config.ProviderConf) error {
-	cmd := fmt.Sprintf("Remove-ADComputer -confirm:$false -Identity %q", m.GUID)
+	cmd := fmt.Sprintf("Remove-ADObject -Confirm:$false -Recursive -Identity %q", m.GUID)
 	conn, err := conf.AcquireWinRMClient()
 	if err != nil {
 		return fmt.Errorf("while acquiring winrm client: %s", err)


### PR DESCRIPTION
### Description

The Remove-ADComputer cmdlet errors out if there are leaf objects attached to an Active Directory computer account. Using the Remove-ADObject cmdlet with the 'Recursive' flag will cause the parent and child objects to be removed from AD.

### References
https://github.com/hashicorp/terraform-provider-ad/issues/154

### Community Note
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
