### PR TITLE
.github/workflows: Switch pr-size-labeler action to upstream

### DIFF
--- a/.github/workflows/pull-request-size.yaml
+++ b/.github/workflows/pull-request-size.yaml
@@ -12,8 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Label the PR size
     steps:
-      # See also: https://github.com/CodelyTV/pr-size-labeler/pull/26
-      - uses: bflad/pr-size-labeler@7df62b12a176513631973abfe151d2b6213c3f12
+      - uses: CodelyTV/pr-size-labeler@54ef36785e9f4cb5ecf1949cfc9b00dbb621d761 # v1.8.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_label: 'size/XS'


### PR DESCRIPTION
### Description

The changes on my fork were merged upstream and I have already deleted my fork (sorry about that).

### References
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
