### PR TITLE
fix: permit explicitly empty group membership

### DIFF
--- a/ad/resource_ad_group_membership.go
+++ b/ad/resource_ad_group_membership.go
@@ -33,7 +33,7 @@ func resourceADGroupMembership() *schema.Resource {
 				Required:    true,
 				Description: "A list of member AD Principals. Each principal can be identified by its GUID, SID, Distinguished Name, or SAM Account Name. Only one is required",
 				Elem:        &schema.Schema{Type: schema.TypeString},
-				MinItems:    1,
+				MinItems:    0,
 			},
 		},
 	}


### PR DESCRIPTION
### Description

Allows explicit declaration of empty groups via `ad_group_membership`.

This greatly simplifies usage of `ad_group_membership` in complex Active-Directory-as-Code scenarios, and fixes an important issue in our production use of `terraform-provider-ad`.

### References

* Fixes #165

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
