### PR TITLE
Fix for user custom attribute issues

### DIFF
--- a/ad/internal/winrmhelper/winrm_helper.go
+++ b/ad/internal/winrmhelper/winrm_helper.go
@@ -126,7 +126,7 @@ func GetString(v interface{}) string {
 	case reflect.String:
 		out = SanitiseString(v.(string))
 	case reflect.Float64:
-		out = strconv.FormatFloat(v.(float64), 'E', -1, 64)
+		out = strconv.FormatFloat(v.(float64), 'f', -1, 64)
 	case reflect.Int64:
 		out = strconv.FormatInt(v.(int64), 10)
 	case reflect.Bool:

--- a/ad/internal/winrmhelper/winrm_user.go
+++ b/ad/internal/winrmhelper/winrm_user.go
@@ -345,10 +345,10 @@ func (u *User) ModifyUser(d *schema.ResourceData, conf *config.ProviderConf) err
 					} else {
 						out = fmt.Sprintf(`"%s"`, newVal.(string))
 					}
-					toReplace = append(toReplace, fmt.Sprintf("%s=%s", SanitiseString(k), out))
+					toReplace = append(toReplace, fmt.Sprintf(`'%s'=%s`, SanitiseString(k), out))
 				}
 			} else {
-				toClear = append(toClear, SanitiseString(k))
+				toClear = append(toClear, fmt.Sprintf(`'%s'`, SanitiseString(k)))
 			}
 		}
 
@@ -366,7 +366,7 @@ func (u *User) ModifyUser(d *schema.ResourceData, conf *config.ProviderConf) err
 				} else {
 					out = newVal.(string)
 				}
-				toAdd = append(toAdd, fmt.Sprintf("%s=%s", SanitiseString(k), out))
+				toAdd = append(toAdd, fmt.Sprintf(`'%s'=%s`, SanitiseString(k), out))
 			}
 		}
 
@@ -491,7 +491,7 @@ func (u *User) getOtherAttributes() (string, error) {
 			}
 			cleanValue = strings.Join(quotedStrings, ",")
 		} else {
-			cleanValue = GetString(v.(string))
+			cleanValue = GetString(v)
 		}
 		out = append(out, fmt.Sprintf(`'%s'=%s`, cleanKey, cleanValue))
 	}


### PR DESCRIPTION
### Description

This PR fixes the issues I reported in #158, where defining `custom_attributes` that included a hypen `-` in the name such as `msDS-SupportedEncryptionTypes` threw errors due to incorrect quoting of hashtable keys.

It also fixes an (unreported?) bug where if a custom_attribute was a large number (e.g. uidNumber = 7333677) it ended up being formatted with an exponent which then threw an error.

Tested successfully on Windows 10 & Alpine with terraform 1.2.7 & 1.4.2

### References

#158 

### Community Note


* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
