### PR TITLE
PSS-277: Bump hashicorp/ghaction-terraform-provider-release/.github/w…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
   terraform-provider-release:
     name: 'Terraform Provider Release'
     needs: [go-version, release-notes]
-    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v2
+    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v4.0.1
     secrets:
       hc-releases-github-token: '${{ secrets.HASHI_RELEASES_GITHUB_TOKEN }}'
       hc-releases-host-staging: '${{ secrets.HC_RELEASES_HOST_STAGING }}'


### PR DESCRIPTION
…orkflows/hashicorp.yml to v4.0.1

This patch bumps hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml to v4.0.1, with the intention of using the new runner labels format (see release notes in https://github.com/hashicorp/ghaction-terraform-provider-release/releases/tag/v4.0.1).

This change is necessary for a runner to pick up jobs using this action.

### Description

<!--- Please leave a helpful description of the pull request here. --->

### References
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
