### PR TITLE
allow ability to query domains

### DIFF
--- a/ad/data_source_ad_domain.go
+++ b/ad/data_source_ad_domain.go
@@ -1,0 +1,67 @@
+package ad
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-ad/ad/internal/config"
+	"github.com/hashicorp/terraform-provider-ad/ad/internal/winrmhelper"
+)
+
+func dataSourceADDomain() *schema.Resource {
+	return &schema.Resource{
+		Description: "Get the details of an Active Directory Computer object.",
+		Read:        dataSourceADDomainRead,
+		Schema: map[string]*schema.Schema{
+			"domain_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The OU's identifier. It can be the OU's GUID, SID, Distinguished Name, or SAM Account Name.",
+			},
+			"guid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The GUID of the domain object.",
+			},
+			"dn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The Distinguished Name of the domain object.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Description: "The name of the domain object.",
+				Computed:    true,
+			},
+			"sid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The SID of the domain object.",
+			},
+		},
+	}
+}
+
+func dataSourceADDomainRead(d *schema.ResourceData, meta interface{}) error {
+	computerID := winrmhelper.SanitiseTFInput(d, "domain_id")
+
+	var identity string
+	if computerID == "" {
+		return fmt.Errorf("invalid inputs for AD computer datasource. domain_id is required")
+	} else {
+		identity = computerID
+	}
+
+	domain, err := winrmhelper.NewDomainFromHost(meta.(*config.ProviderConf), identity)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(domain.GUID)
+	_ = d.Set("name", domain.Name)
+	_ = d.Set("dn", domain.DN)
+	_ = d.Set("guid", domain.GUID)
+	_ = d.Set("sid", domain.SID.Value)
+
+	return nil
+}

--- a/ad/internal/winrmhelper/winrm_domain.go
+++ b/ad/internal/winrmhelper/winrm_domain.go
@@ -1,0 +1,75 @@
+package winrmhelper
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-ad/ad/internal/config"
+)
+
+// Domain struct represents an AD Domain account object
+type Domain struct {
+	Name string `json:"Name"`
+	GUID string `json:"ObjectGuid"`
+	DN   string `json:"DistinguishedName"`
+	SID  SID    `json:"DomainSID"`
+}
+
+// NewDomainFromResource returns a new Machine struct populated from resource data
+func NewDomainFromResource(d *schema.ResourceData) *Domain {
+	return &Domain{
+		Name: SanitiseTFInput(d, "name"),
+		DN:   SanitiseTFInput(d, "dn"),
+		GUID: SanitiseTFInput(d, "guid"),
+	}
+}
+
+// NewDomainFromHost return a new Machine struct populated from data we get
+// from the domain controller
+func NewDomainFromHost(conf *config.ProviderConf, identity string) (*Domain, error) {
+	cmd := fmt.Sprintf("Get-ADDomain -Identity %q", identity)
+	conn, err := conf.AcquireWinRMClient()
+	if err != nil {
+		return nil, fmt.Errorf("while acquiring winrm client: %s", err)
+	}
+	defer conf.ReleaseWinRMClient(conn)
+	psOpts := CreatePSCommandOpts{
+		JSONOutput:      true,
+		ForceArray:      false,
+		ExecLocally:     conf.IsConnectionTypeLocal(),
+		PassCredentials: conf.IsPassCredentialsEnabled(),
+		Username:        conf.Settings.WinRMUsername,
+		Password:        conf.Settings.WinRMPassword,
+		Server:          conf.IdentifyDomainController(),
+	}
+	psCmd := NewPSCommand([]string{cmd}, psOpts)
+	result, err := psCmd.Run(conf)
+	if err != nil {
+		return nil, fmt.Errorf("winrm execution failure in NewDomainFromHost: %s", err)
+	}
+
+	if result.ExitCode != 0 {
+		return nil, fmt.Errorf("Get-ADDomain exited with a non zero exit code (%d), stderr: %s", result.ExitCode, result.StdErr)
+	}
+	domain, err := unmarshallDomain([]byte(result.Stdout))
+	if err != nil {
+		return nil, fmt.Errorf("NewDomainFromHost: %s", err)
+	}
+
+	return domain, nil
+}
+
+func unmarshallDomain(input []byte) (*Domain, error) {
+	var domain Domain
+	err := json.Unmarshal(input, &domain)
+	if err != nil {
+		log.Printf("[DEBUG] Failed to unmarshall an ADDomain json document with error %q, document was %s", err, string(input))
+		return nil, fmt.Errorf("failed while unmarshalling ADDomain json document: %s", err)
+	}
+	if domain.GUID == "" {
+		return nil, fmt.Errorf("invalid data while unmarshalling Domain data, json doc was: %s", string(input))
+	}
+	return &domain, nil
+}

--- a/ad/provider.go
+++ b/ad/provider.go
@@ -117,6 +117,7 @@ func Provider() *schema.Provider {
 			"ad_gpo":      dataSourceADGPO(),
 			"ad_computer": dataSourceADComputer(),
 			"ad_ou":       dataSourceADOU(),
+			"ad_domain":   dataSourceADDomain(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"ad_user":             resourceADUser(),


### PR DESCRIPTION
### Description

Currently the provider does not have support for query an AD Domain. This adds the functionality to use the domain as a data source; I would have included resource but only get and update functionalities exist in current PowerShell module.

### References
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

N/A

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
