### PR TITLE
fix: Remember Group Membership Names

### DIFF
--- a/ad/resource_ad_group_membership.go
+++ b/ad/resource_ad_group_membership.go
@@ -29,11 +29,41 @@ func resourceADGroupMembership() *schema.Resource {
 				ForceNew:    true,
 			},
 			"group_members": {
-				Type:        schema.TypeSet,
-				Required:    true,
-				Description: "A list of member AD Principals. Each principal can be identified by its GUID, SID, Distinguished Name, or SAM Account Name. Only one is required",
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				MinItems:    1,
+				Type:             schema.TypeSet,
+				Required:         true,
+				Description:      "A list of member AD Principals. Each principal can be identified by its GUID, SID, Distinguished Name, or SAM Account Name. Only one is required",
+				Elem:             &schema.Schema{Type: schema.TypeString},
+				MinItems:         1,
+				DiffSuppressFunc: suppressGroupMemberDiff,
+			},
+			"group_members_details": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"guid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"dn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"sam_account_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"sid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"identity": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+				Description: "Detailed attributes of group members, resolved internally by the provider.",
 			},
 		},
 	}
@@ -46,12 +76,29 @@ func resourceADGroupMembershipRead(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return err
 	}
-	memberList := make([]string, len(gm.GroupMembers))
+	memberList := d.Get("group_members").(*schema.Set).List()
+	memberDetails := []map[string]string{}
 
-	for idx, m := range gm.GroupMembers {
-		memberList[idx] = m.GUID
+	for _, identity := range memberList {
+		id := strings.Trim(identity.(string), "\"")
+		for _, mbr := range gm.GroupMembers {
+			if id == mbr.GUID || id == mbr.DN || id == mbr.SamAccountName || id == mbr.SID.Value {
+				// Resolve additional details for each member
+				details := map[string]string{
+					"guid":             mbr.GUID,
+					"dn":               mbr.DN,
+					"sam_account_name": mbr.SamAccountName,
+					"sid":              mbr.SID.Value,
+					"identity":         identity.(string),
+				}
+				memberDetails = append(memberDetails, details)
+				break
+			}
+		}
 	}
+
 	_ = d.Set("group_members", memberList)
+	_ = d.Set("group_members_details", memberDetails)
 	_ = d.Set("group_id", toks[0])
 	return nil
 }
@@ -105,4 +152,23 @@ func resourceADGroupMembershipDelete(d *schema.ResourceData, meta interface{}) e
 
 	d.SetId("")
 	return nil
+}
+
+func suppressGroupMemberDiff(k, old, new string, d *schema.ResourceData) bool {
+	strippedNew := strings.Trim(new, "\"")
+
+	// Get the resolved member details from the state
+	memberDetails := d.Get("group_members_details").(*schema.Set).List()
+
+	for _, member := range memberDetails {
+		// Check if the new value matches any of the saved group member details
+		for _, member := range member.(map[string]string) {
+			if member == strippedNew {
+				// Match found, suppress the diff
+				return true
+			}
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
### Description

As per Issue https://github.com/hashicorp/terraform-provider-ad/issues/196, `ad_group_membership` stores only a member's GUID in the state file. So, when the configuration uses `SamAccountName`, `DN` or `SID`, a terraform refresh / plan will try and remove and re-add the group member each time. I do not plan on putting member `GUID`s in the configuration, which would be a nightmare to maintain.

I need this because I've implemented RBAC groups and memberships with this terraform provider for a client and have nearly 300 ad_groups and ad_group_memberships to modify each run, so the current behaviour of trying to remove and re-add each group membership is unacceptable.

This patch Computes `GUID`, `DN`, `SID` and `SamAccountName` from Active Directory, and stores them in the State file. On refresh / plan, a `DiffSuppressFunc` function compares the `Identity` in the configuration, to all of those attributes, so only produces a diff if there is a true change in the group_members of `ad_group_membership`.

@Yrix90 proposed adding a `membership_attribute` to the configuration, allowing users to specify what attribute to compare between the Configuration and Host. What I didn't like is that the patch doesn't allow a mix of Identity types, which this PR would allow, while negating the need to add an extra `membership_attribute` to the configuration. So, this PR allows users to use a mix of attribute types for group_members. e.g. Groups may be referenced `SamAccountName`, Users by `DN`, for example, or just a complete mix-and-match.

One other change perhaps worth mentioning. I have changed the `GroupMember` struct in [`ad/internal/winrmhelper/winrm_group_membership.go`](https://github.com/hashicorp/terraform-provider-ad/compare/main...alexleach:terraform-provider-ad:main#diff-6ec3a81d3dc859201b6536a64ac711508b207792edd254b784b86f782fe7f992) which represents the `group_members` list of strings entered into the configuration, renaming `Name` to `Identity`. The Active Directory schema has a `Name` attribute for Users and Groups, but Users and Groups can't be found by their `Name`, as it is not guaranteed to be unique. So, to avoid confusion, I've changed this to `Identity`, which is how the parameter is named in `Get-ADObject`, `Get-ADUser` and `Get-ADGroup`, e.g.

```powershell
PS C:\Users\a.leach> Get-Help Get-ADObject

NAME
    Get-ADGroup

SYNTAX

    Get-ADGroup **[-Identity]** <ADGroup> [-AuthType {Negotiate | Basic}] [-Credential <pscredential>] [-Partition
    <string>] [-Properties <string[]>] [-Server <string>] [-ShowMemberTimeToLive]  [<CommonParameters>]

```

### References
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

Fixes Issue https://github.com/hashicorp/terraform-provider-ad/issues/196
Supersedes PR https://github.com/hashicorp/terraform-provider-ad/pull/208

### Personal Note
This is my first time writing any Go code, and I've only used terraform a small handful of times. So, this took me an embarrassingly long amount of time to figure out and get working, even with a lot of assistance from VS Code CoPilot!

The schema modifications in [`ad/resource_ad_group_membership.go`](https://github.com/hashicorp/terraform-provider-ad/compare/main...alexleach:terraform-provider-ad:main#diff-6ec3a81d3dc859201b6536a64ac711508b207792edd254b784b86f782fe7f992) could probably be improved from my implementation. I currently store `group_members` and `group_member_details` as two `TypeSets`, so each time one needs to look up a specific group_member's details, I need to look through the set comparing attributes. A `TypeMap` would probably be better, but either way, it works.



### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
